### PR TITLE
Correcting ZendDiactoros\ResponseEmitter typo (capitalisation fail)

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -47,7 +47,7 @@ class Config extends ContainerConfig
 
 		// Specify we want to use Zend Diactoros for our PSR7 stuff
 		$container->types[\Weave\Http\ResponseEmitterInterface::class] = $container->lazyNew(
-			\Weave\Http\ZendDiactoros\responseEmitter::class
+			\Weave\Http\ZendDiactoros\ResponseEmitter::class
 		);
 
 		$container->types[\Weave\Http\RequestFactoryInterface::class] = $container->lazyNew(


### PR DESCRIPTION
The Double Pass example now works \o/ I suspect this is due to OS X's case preserving/case-insensitive behaviour.